### PR TITLE
Added Docker integration for CICD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Put here files to be ingored when building docker image
+dist
+.gitignore
+.prettier*
+README.md
+node_modules
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+COPY . .
+
+RUN ["yarn"]
+
+CMD ["/bin/sh","-c", "yarn run deploy && yarn run start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.5'
+
+services:
+
+  # Disocrd bot service
+  discord-bot:
+ 
+    # Building the image
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    # IMPORTANT: If you want to redeploy you will need to change the version number
+    image: frontlive-discord-bot:v.0.0.2
+
+    # Standard settings
+    container_name: frontlive-discord-bot
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+
+    # Enviroment
+    environment:
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - OWNERS=${OWNERS}
+      - THANKS_MESSAGE_CHANNEL_TARGET_ID=${THANKS_MESSAGE_CHANNEL_TARGET_ID}
+      - DATABASE_URL=${DATABASE_URL}
+

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "watch:start": "tsc-watch --onSuccess \"node ./dist/index.js\"",
     "format": "prettier --write \"src/**/*.ts\"",
     "prisma-generate": "prisma generate --schema=./src/prisma/schema.prisma",
-    "prisma-migrate": "prisma migrate dev --schema=./src/prisma/schema.prisma"
+    "prisma-migrate": "prisma migrate dev --schema=./src/prisma/schema.prisma",
+    "deploy": "tsc && yarn prisma-generate && prisma migrate deploy --schema=./src/prisma/schema.prisma"
   },
   "prettier": "./.prettierrc.json"
 }


### PR DESCRIPTION
For this to work the repository must have webhook setup to provided portainer webhook url.
This option can be found in Settings/Webhooks.

Additional Webhooks settings
- Which events would you like to trigger this webhook? -> Just the push event.
- Content type -> application/json

Portainer is quite derpy with webhooks thus failed webhook interactions means sucess and sucess interactions means that nothing was done.

For autodeploy to work you will need to bump up version tag in docker-compose.yml