### PR TITLE
Fix CO XDDDD command

### DIFF
--- a/src/commands/Co.ts
+++ b/src/commands/Co.ts
@@ -13,7 +13,7 @@ export class CoCommand extends SubCommandPluginCommand {
   public async messageRun(message: Message) {
     return message.channel.send({
       files: ['https://i.imgur.com/Jhng0EF.png'],
-      content: '',
+      content: 'CO XDDDD',
     });
   }
 }


### PR DESCRIPTION
Apparently `content` cannot be an empty string, so the CO XDDDD command will now also send a `CO XDDDD` message in it